### PR TITLE
Ensembl fixes

### DIFF
--- a/profile/non-interactive/general.sh
+++ b/profile/non-interactive/general.sh
@@ -31,8 +31,10 @@ export RSYNC_FLAGS="--archive --delete-before --human-readable --progress --recu
 export TODAY=$(date +%Y-%m-%d)
 
 # Annotation database paths
-export ENSEMBL_RELEASE="91"
+# Ensembl: Match latest release available in AnnotationHub
+export ENSEMBL_RELEASE="90"
 export ENSEMBL_RELEASE_PATH="ftp://ftp.ensembl.org/pub/release-${ENSEMBL_RELEASE}"
+# FlyBase
 export FLYBASE_RELEASE="FB2017_06"
 export FLYBASE_RELEASE_VERSION="6.19"
 export FLYBASE_RELEASE_PATH="ftp://ftp.flybase.net/releases/$FLYBASE_RELEASE/dmel_r${FLYBASE_RELEASE_VERSION}"

--- a/workflows/bcbio/rnaseq/hsapiens_grch37.yaml
+++ b/workflows/bcbio/rnaseq/hsapiens_grch37.yaml
@@ -1,0 +1,24 @@
+# Template for RNA-seq using Illumina prepared samples
+#
+# Homo sapiens
+# 2018-03-16
+#
+# Genome build: GRCh37
+# Release version: 90
+# Legacy release version: 75
+# FASTA: ftp://ftp.ensembl.org/pub/grch37/release-90/fasta/homo_sapiens/cdna/Homo_sapiens.GRCh37.cdna.all.fa.gz
+# GTF: ftp://ftp.ensembl.org/pub/grch37/release-90/gtf/homo_sapiens/Homo_sapiens.GRCh37.87.chr_patch_hapl_scaff.gtf.gz
+#
+# NOTE: genome_build is specific to bcbio install
+---
+details:
+  - analysis: RNA-seq
+    genome_build: GRCh37_90
+    algorithm:
+      aligner: star
+      expression_caller: salmon
+      strandedness: unstranded
+      transcriptome_fasta: Homo_sapiens.GRCh37.cdna.all.fa
+      transcriptome_gtf: Homo_sapiens.GRCh37.87.chr_patch_hapl_scaff.gtf
+upload:
+  dir: ../final


### PR DESCRIPTION
- Add RNA-seq template example for GRCh37.
- Match automatic FASTA and GTF downloads to latest version available on AnnotationHub (Bioconductor 3.6 currently).