### PR TITLE
2018-04-27

### DIFF
--- a/functions/fastq_dump.sh
+++ b/functions/fastq_dump.sh
@@ -12,8 +12,6 @@ while read name; do
     if [[ ! -e $name.fastq.gz ]] && [[ ! -e $name_1.fastq.gz ]]; then
         echo "$name"
         fastq-dump --gzip --split-3 --accession "$name"
-        # Remove SRA cache file upon completion
-        # rm ~/ncbi/public/sra/"$name".sra
     fi
 done < ../SRR_Acc_List.txt
 cd ..

--- a/functions/fastq_dump.sh
+++ b/functions/fastq_dump.sh
@@ -6,9 +6,9 @@ command -v fastq-dump >/dev/null 2>&1 || {
     return 1
 }
 
-while read name; do
-    if [[ ! -e $name.fastq.gz ]] && [[ ! -e $name_1.fastq.gz ]]; then
-        echo "$name"
-        fastq-dump --gzip --split-3 --accession "$name"
+while read accession; do
+    if [[ ! -e $accession.fastq.gz ]] && [[ ! -e $accession_1.fastq.gz ]]; then
+        echo "$accession"
+        fastq-dump --gzip --split-3 "$accession"
     fi
 done < SRR_Acc_List.txt

--- a/functions/fastq_dump.sh
+++ b/functions/fastq_dump.sh
@@ -1,4 +1,4 @@
-# This requires fastq-dump from sra-tools
+# FASTQ dump from SRA file requires sra-tools
 # https://github.com/ncbi/sra-tools
 
 command -v fastq-dump >/dev/null 2>&1 || {
@@ -6,18 +6,12 @@ command -v fastq-dump >/dev/null 2>&1 || {
     return 1
 }
 
-# Check for LSF
-if [[ -z $LSF_ENVDIR ]]; then
-    echo "LSF required"
-    return 1
-fi
-
 mkdir -p fastq
 cd fastq
 while read name; do
     if [[ ! -e $name.fastq.gz ]] && [[ ! -e $name_1.fastq.gz ]]; then
         echo "$name"
-        bsub -q priority -W 6:00 fastq-dump --gzip --split-3 --accession "$name"
+        fastq-dump --gzip --split-3 --accession "$name"
         # Remove SRA cache file upon completion
         rm ~/ncbi/public/sra/"$name".sra
     fi

--- a/functions/fastq_dump.sh
+++ b/functions/fastq_dump.sh
@@ -13,7 +13,7 @@ while read name; do
         echo "$name"
         fastq-dump --gzip --split-3 --accession "$name"
         # Remove SRA cache file upon completion
-        rm ~/ncbi/public/sra/"$name".sra
+        # rm ~/ncbi/public/sra/"$name".sra
     fi
 done < ../SRR_Acc_List.txt
 cd ..

--- a/functions/fastq_dump.sh
+++ b/functions/fastq_dump.sh
@@ -6,12 +6,9 @@ command -v fastq-dump >/dev/null 2>&1 || {
     return 1
 }
 
-mkdir -p fastq
-cd fastq
 while read name; do
     if [[ ! -e $name.fastq.gz ]] && [[ ! -e $name_1.fastq.gz ]]; then
         echo "$name"
         fastq-dump --gzip --split-3 --accession "$name"
     fi
-done < ../SRR_Acc_List.txt
-cd ..
+done < SRR_Acc_List.txt

--- a/functions/interactive.sh
+++ b/functions/interactive.sh
@@ -13,7 +13,7 @@ fi
 
 # All arguments are optional
 cores=1
-mem=1
+mem=4
 # time
 if [[ "$SCHEDULER" == "slurm" ]]; then
     time="0-06:00"

--- a/profile/non-interactive/conda.sh
+++ b/profile/non-interactive/conda.sh
@@ -11,7 +11,7 @@ fi
 if [[ -d "$CONDA_DIR" ]]; then
     export CONDA_VERSION=$($CONDA_DIR/bin/conda --version)
     # Ensure load script is sourced for v4.4+
-    if echo "$CONDA_VERSION" | grep -q "conda 4.4"; then
+    if echo "$CONDA_VERSION" | grep -q "conda 4.[4-9]"; then
         . "${CONDA_DIR}/etc/profile.d/conda.sh"
     fi
 fi

--- a/profile/non-interactive/general.sh
+++ b/profile/non-interactive/general.sh
@@ -30,7 +30,8 @@ export RSYNC_FLAGS="--archive --delete-before --human-readable --progress --recu
 
 export TODAY=$(date +%Y-%m-%d)
 
-# Ensembl: Match latest release available in AnnotationHub (Bioconductor 3.7)
+# Ensembl
+# Match latest release available in AnnotationHub (Bioconductor 3.7)
 export ENSEMBL_RELEASE="92"
 export ENSEMBL_RELEASE_PATH="ftp://ftp.ensembl.org/pub/release-${ENSEMBL_RELEASE}"
 

--- a/profile/non-interactive/general.sh
+++ b/profile/non-interactive/general.sh
@@ -31,7 +31,7 @@ export RSYNC_FLAGS="--archive --delete-before --human-readable --progress --recu
 export TODAY=$(date +%Y-%m-%d)
 
 # Ensembl: Match latest release available in AnnotationHub
-export ENSEMBL_RELEASE="90"
+export ENSEMBL_RELEASE="92"
 export ENSEMBL_RELEASE_PATH="ftp://ftp.ensembl.org/pub/release-${ENSEMBL_RELEASE}"
 
 # FlyBase

--- a/profile/non-interactive/general.sh
+++ b/profile/non-interactive/general.sh
@@ -30,7 +30,7 @@ export RSYNC_FLAGS="--archive --delete-before --human-readable --progress --recu
 
 export TODAY=$(date +%Y-%m-%d)
 
-# Ensembl: Match latest release available in AnnotationHub
+# Ensembl: Match latest release available in AnnotationHub (Bioconductor 3.7)
 export ENSEMBL_RELEASE="92"
 export ENSEMBL_RELEASE_PATH="ftp://ftp.ensembl.org/pub/release-${ENSEMBL_RELEASE}"
 

--- a/profile/non-interactive/general.sh
+++ b/profile/non-interactive/general.sh
@@ -35,6 +35,6 @@ export ENSEMBL_RELEASE="92"
 export ENSEMBL_RELEASE_PATH="ftp://ftp.ensembl.org/pub/release-${ENSEMBL_RELEASE}"
 
 # FlyBase
-export FLYBASE_RELEASE="FB2017_06"
-export FLYBASE_RELEASE_VERSION="6.19"
+export FLYBASE_RELEASE="FB2018_02"
+export FLYBASE_RELEASE_VERSION="6.21"
 export FLYBASE_RELEASE_PATH="ftp://ftp.flybase.net/releases/$FLYBASE_RELEASE/dmel_r${FLYBASE_RELEASE_VERSION}"

--- a/profile/non-interactive/harvard_o2.sh
+++ b/profile/non-interactive/harvard_o2.sh
@@ -1,9 +1,9 @@
 # HMS RC: Harvard Medical School Research Computing
 
 # HPC environment variable
-if [[ $HMS_CLUSTER = "o2" ]] && \
+if [[ $HMS_CLUSTER == "o2" ]] && \
     [[ $HOSTNAME =~ ".o2.rc.hms.harvard.edu" ]] && \
-    [[ $(uname -s) = "Linux" ]] && \
+    [[ $(uname -s) == "Linux" ]] && \
     [[ -d /n/data1/ ]]
 then
     # O2

--- a/profile/non-interactive/harvard_odyssey.sh
+++ b/profile/non-interactive/harvard_odyssey.sh
@@ -1,6 +1,6 @@
 # HPC environment variable
 if [[ $HOSTNAME =~ ".rc.fas.harvard.edu" ]] || \
-    [[ $(uname -s) = "Linux" ]] && \
+    [[ $(uname -s) == "Linux" ]] && \
     [[ -d /n/regal/ ]]
 then
     export HPC="Harvard FAS Odyssey"


### PR DESCRIPTION
- Increased memory for default interactive session from 1 GB to 4 GB.
- Simplified fastq-dump script to work interactively and not attempt scheduler submissions.
- Now recommending Ensembl 92 for annotations, matching Bioconductor 3.7.